### PR TITLE
Remove extra param from byteidx

### DIFF
--- a/lua/multicursors/selections.lua
+++ b/lua/multicursors/selections.lua
@@ -56,7 +56,7 @@ end
 ---@return integer
 local function find_last_char_byte_idx(text)
     local charlen = vim.fn.strcharlen(text)
-    return vim.fn.byteidx(text, charlen - 1, false) or -1
+    return vim.fn.byteidx(text, charlen - 1) or -1
 end
 
 --- Reduces the selection to the char before it
@@ -99,7 +99,7 @@ local function reduce_to_after(selection, text)
         return selection
     end
     selection.col = selection.end_col
-    selection.end_col = vim.fn.byteidx(text, 1, false) + selection.end_col
+    selection.end_col = vim.fn.byteidx(text, 1) + selection.end_col
     selection.row = selection.end_row
     return selection
 end


### PR DESCRIPTION
I was getting an error when entering insert mode after enabling the Multicursor mode.
It seems that Neovim 0.9.0 has only 2 parameters required for the byteidx function.

![image](https://github.com/smoka7/multicursors.nvim/assets/8898038/2422d2ee-c33c-4d2c-99d6-7f4b5a8310fc)

![image](https://github.com/smoka7/multicursors.nvim/assets/8898038/3c01758a-54bb-4e92-a6da-c4d942ccb73f)
