### PR TITLE
feat(highlights): allow overriding highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ lualine_b = {
  }
 ```
 
+# Highlight Groups
+The following groups are used by `multicursors.nvim` and can be overriden:
+
+| Name | Description |
+|---|---|
+| MultiCursor | Multicursor selections. |
+| MultiCursorMain | Main selection in which multicursor began. |
+
 # Acknowledgment
 
 [vim-visual-multi](https://github.com/mg979/vim-visual-multi)

--- a/lua/multicursors/highlight.lua
+++ b/lua/multicursors/highlight.lua
@@ -2,11 +2,15 @@
 local M = {}
 
 function M.set_highlights()
-    vim.api.nvim_set_hl(0, 'MultiCursor', { fg = '#DBEC6B', bg = '#161714' })
+    vim.api.nvim_set_hl(
+        0,
+        'MultiCursor',
+        { fg = '#DBEC6B', bg = '#161714', default = true }
+    )
     vim.api.nvim_set_hl(
         0,
         'MultiCursorMain',
-        { fg = '#d6f31f', bg = '#161714', bold = true }
+        { fg = '#d6f31f', bg = '#161714', bold = true, default = true }
     )
 end
 


### PR DESCRIPTION
Adding `default = true` to the highlight group options to allow users to override these.