### PR TITLE
feat(hints): allow functions in generate_hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Install with your preferred package manager:
     -- -1 true: generate hints
     -- -2 false: don't generate hints
     -- -3 [[multi line string]] provide your own hints
+    -- -4 fun(heads: Head[]): string - provide your own hints
     generate_hints = {
         normal = false,
         insert = false,

--- a/lua/multicursors/config.lua
+++ b/lua/multicursors/config.lua
@@ -145,7 +145,8 @@ local M = {
     -- accepted values:
     -- -1 true: generate hints
     -- -2 false: don't generate hints
-    -- -3 [[multi line string]] provide your own hints
+    -- -3 [[multi line string]] - provide your own hints
+    -- -4 fun(heads: Head[]): string - provide your own hints
     generate_hints = {
         normal = false,
         insert = false,

--- a/lua/multicursors/layers.lua
+++ b/lua/multicursors/layers.lua
@@ -30,9 +30,9 @@ local generate_heads = function(keys, nowait, show_desc)
         if action.method ~= false then
             local opts = action.opts or {}
 
-            opts.description = nil
+            opts.desc = nil
             if action.opts and show_desc then
-                opts.description = action.opts.desc
+                opts.desc = action.opts.desc
             end
 
             if action.opts.nowait ~= nil then

--- a/lua/multicursors/layers.lua
+++ b/lua/multicursors/layers.lua
@@ -84,6 +84,8 @@ local generate_hints = function(config, heads, mode)
         return 'MultiCursor ' .. mode .. ' mode'
     elseif type(config.generate_hints[mode]) == 'string' then
         return config.generate_hints[mode]
+    elseif type(config.generate_hints[mode]) == 'function' then
+        return config.generate_hints[mode](heads)
     end
 
     table.sort(heads, function(a, b)


### PR DESCRIPTION
_(Sorry for the PR bombardment hehe)_

For a more flexible customization of hints, this PR adds a function variant of `generate_hints[mode]` that takes as input the Hydra heads and should return a string.

Also piggy-backing what seems to be a bug. In the code below we're trying to access `description` from `HeadOpts`, but [there's no such field](https://github.com/smoka7/multicursors.nvim/blob/c75d0f2594f8faa766682afecd4a6d6fa26b3974/lua/multicursors/types.lua#L30-L40). My educated guess is that `desc` was meant to be used here instead.
https://github.com/smoka7/multicursors.nvim/blob/c75d0f2594f8faa766682afecd4a6d6fa26b3974/lua/multicursors/layers.lua#L33-L35