### PR TITLE
feat(hints): add width option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Install with your preferred package manager:
         config = {
              -- determines how many columns are used to display the hints. If you leave this option nil, the number of columns will depend on the size of your window.
             column_count = nil,
+            -- maximum width of a column.
+            max_hint_length = 25,
         }
     },
 }

--- a/lua/multicursors/config.lua
+++ b/lua/multicursors/config.lua
@@ -154,6 +154,8 @@ local M = {
         config = {
             -- determines how many columns are used to display the hints. If you leave this option nil, the number of columns will depend on the size of your window.
             column_count = nil,
+            -- maximum width of a column.
+            max_hint_length = 25,
         },
     },
 }

--- a/lua/multicursors/layers.lua
+++ b/lua/multicursors/layers.lua
@@ -46,13 +46,12 @@ local set_heads_options = function(keys, nowait)
     return heads
 end
 
-local max_hint_length = 25
-
 --- Creates a hint for a head
 --- when necessary adds padding or cuts the hint for aligning
 ---@param head Head
+---@param max_hint_length integer
 ---@return string
-local function get_hint(head)
+local function get_hint(head, max_hint_length)
     if not head[3].desc or head[3].desc == '' then
         return ''
     end
@@ -102,6 +101,7 @@ local generate_hints = function(config, heads, mode)
 
     local str = ' MultiCursor: ' .. mode .. ' mode'
 
+    local max_hint_length = config.generate_hints.config.max_hint_length
     local columns = config.generate_hints.config.column_count
         or math.floor(
             vim.api.nvim_get_option_value('columns', {}) / max_hint_length
@@ -112,7 +112,8 @@ local generate_hints = function(config, heads, mode)
         line = ''
         for j = 1, columns, 1 do
             if heads[(i * columns) + j] then
-                line = line .. get_hint(heads[(i * columns) + j])
+                line = line
+                    .. get_hint(heads[(i * columns) + j], max_hint_length)
             end
         end
 

--- a/lua/multicursors/types.lua
+++ b/lua/multicursors/types.lua
@@ -47,6 +47,7 @@
 
 ---@class GenerateHintsConfig
 ---@field column_count? integer
+---@field max_hint_length integer
 
 ---@class Config
 ---@field generate_hints GenerateHints


### PR DESCRIPTION
With the vertical layout introduced in #57, being able to configure the width of window would be nice since the narrow layout causes most of the hints to be truncated:

<img width="389" alt="Screenshot 2023-10-15 at 4 32 23 PM" src="https://github.com/smoka7/multicursors.nvim/assets/62502207/b43e19da-d727-44da-b52e-8c094a585bae">
