### PR TITLE
map i_ctrl-] to noop

### DIFF
--- a/lua/multicursors/insert_mode.lua
+++ b/lua/multicursors/insert_mode.lua
@@ -37,6 +37,7 @@ M._on_insert_char_pre = function()
     api.nvim_create_autocmd({ 'InsertCharPre' }, {
         group = M._au_group,
         callback = function()
+            if vim.v.char == '\x1d' then return end
             M._inserted_text = M._inserted_text .. vim.v.char
         end,
     })


### PR DESCRIPTION
There are some plugins which use `i_ctrl-]` to expand abbreviations (like [nvim-autopairs](https://github.com/windwp/nvim-autopairs) with `enable_abbr = true`, [autoclose.nvim](https://github.com/m4xshen/autoclose.nvim) and [ultimate-autopair.nvim](https://github.com/altermo/ultimate-autopair.nvim)). Until neovim introduces an API for expanding abbreviations, we can map `i_ctrl-]` to noop so that such plugins don't insert a character that the user didn't intend to insert.