### PR TITLE
feat: Switch to maintained fork of hydra.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install with your preferred package manager:
     "smoka7/multicursors.nvim",
     event = "VeryLazy",
     dependencies = {
-        'smoka7/hydra.nvim',
+        'nvimtools/hydra.nvim',
     },
     opts = {},
     cmd = { 'MCstart', 'MCvisual', 'MCclear', 'MCpattern', 'MCvisualPattern', 'MCunderCursor' },

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Install with your preferred package manager:
     extend_keys = extend_keys,
     -- see :help hydra-config.hint
     hint_config = {
-        border = 'none',
+        float_opts = {
+            border = 'none',
+        },
         position = 'bottom',
     },
     -- accepted values:
@@ -91,7 +93,7 @@ To enter Multicursor mode, use one of the above commands.
 
 ## Multi cursor mode
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Keys that aren't mapped **do not affect other selections** .
 
 <details>
@@ -135,7 +137,7 @@ To enter Multicursor mode, use one of the above commands.
 | `@` | Executes a macro at the start of selections |
 | `.` | Repeats last change at the start of selections |
 | `,` | Clears All Selections except the main one |
-| `:` | Prompts for a normal command and Executes it at the start of selections | 
+| `:` | Prompts for a normal command and Executes it at the start of selections |
 | `u` | Undo changes |
 | `<C-r>` | Redo changes |
 
@@ -266,7 +268,9 @@ A configuration like this can be used to show hints in a vertical window similar
 ```lua
  require('multicursors').setup {
     hint_config = {
-        border = 'rounded',
+        float_opts = {
+            border = 'rounded',
+        },
         position = 'bottom-right',
     },
     generate_hints = {

--- a/doc/multicursors.txt
+++ b/doc/multicursors.txt
@@ -42,7 +42,7 @@ Install with your preferred package manager:
         "smoka7/multicursors.nvim",
         event = "VeryLazy",
         dependencies = {
-            'smoka7/hydra.nvim',
+            'nvimtools/hydra.nvim',
         },
         opts = {},
         cmd = { 'MCstart', 'MCvisual', 'MCclear', 'MCpattern', 'MCvisualPattern', 'MCunderCursor' },

--- a/doc/multicursors.txt
+++ b/doc/multicursors.txt
@@ -80,7 +80,9 @@ Click me ~
         extend_keys = extend_keys,
         -- see :help hydra-config.hint
         hint_config = {
-            border = 'none',
+            float_opts = {
+                border = 'none',
+            },
             position = 'bottom',
         },
         -- accepted values:
@@ -384,12 +386,12 @@ Disable the hint window and show Multicursor mode in your status line.
      require('multicursors').setup {
         hint_config = false,
     }
-    
+
     local function is_active()
         local ok, hydra = pcall(require, 'hydra.statusline')
         return ok and hydra.is_active()
     end
-    
+
     local function get_name()
         local ok, hydra = pcall(require, 'hydra.statusline')
         if ok then
@@ -397,7 +399,7 @@ Disable the hint window and show Multicursor mode in your status line.
         end
         return ''
     end
-    
+
     --- for lualine add this component
     lualine_b = {
         { get_name, cond = is_active },
@@ -413,7 +415,9 @@ similar to helix.
 >lua
      require('multicursors').setup {
         hint_config = {
-            border = 'rounded',
+            float_opts = {
+                border = 'rounded',
+            },
             position = 'bottom-right',
         },
         generate_hints = {

--- a/lua/multicursors/config.lua
+++ b/lua/multicursors/config.lua
@@ -143,7 +143,9 @@ local M = {
     extend_keys = extend_keys,
     -- see :help hydra-config.hint
     hint_config = {
-        border = 'none',
+        float_opts = {
+            border = 'none',
+        },
         position = 'bottom',
     },
     -- accepted values:

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -22,7 +22,7 @@ if plenary_exists then
 end
 
 if hydra_exists then
-    clone('https://github.com/smoka7/hydra.nvim', hydra_dir)
+    clone('https://github.com/nvimtools/hydra.nvim', hydra_dir)
 end
 
 vim.opt.directory = ''


### PR DESCRIPTION
Running this plugin with the maintained fork of `hydra.nvim` gives me:
```
ERROR: [Hydra.nvim] Option "hint.border" has been deprecated and will be removed on 2024-02-01 -- See hint.float_opts
```

This PR addresses this:
- Switch from [smoka7/hydra.nvim](https://github.com/smoka7/hydra.nvim) to [nvimtools/hydra.nvim](https://github.com/nvimtools/hydra.nvim)
- use `float_opts.border` instead of [deprecated](https://github.com/nvimtools/hydra.nvim/blob/8578056a2226ed49fc608167edc143a87f75d809/lua/hydra/lib/types.lua#L37) `border`.
