### PR TITLE
fix replace exception

### DIFF
--- a/lua/multicursors/normal_mode.lua
+++ b/lua/multicursors/normal_mode.lua
@@ -216,6 +216,8 @@ M.replace = function()
                 selection.end_col,
                 content
             )
+
+            selection.end_col = selection.col + #content[1]
         end)
         return
     end
@@ -230,6 +232,8 @@ M.replace = function()
             selection.end_col,
             { content[index] }
         )
+
+        selection.end_col = selection.col + #content[index]
         index = index + 1
     end)
 end


### PR DESCRIPTION
# modify content
when call function update_selections_with,
```
M.update_selections_with = function(callback)
    local marks = M.get_all_selections()
    -- Get each mark again cause editing buffer might moves the other marks
    for _, selection in pairs(marks) do
        -- ...
        local s = {
            id = selection.id,
            row = mark[1],
            col = mark[2],
            end_row = mark[3].end_row,
            end_col = mark[3].end_col,
        }

        -- Delete each mark and recreate it after running callbacks
        api.nvim_buf_del_extmark(0, ns_id, s.id)
        callback(s)
        M.create_extmark(s, 'MultiCursor')
    end

    -- ...
end

```

in every loop that will cal callback function of replace
```
        utils.update_selections_with(function(selection)
            api.nvim_buf_set_text(
                0,
                selection.row,
                selection.col,
                selection.end_row,
                selection.end_col,
                content
            )

            -- selection.end_col = selection.col + #content[1]
            -- current fix solution
        end)
        return

```
after the selection length will change, but the s cache haven't change,so when this line "M.create_extmark(s, 'MultiCursor')" be call, the end_col will beyond the range

# test step
1. use "ye" to copy some code to register which will beyond the selection
2. select some content
3. use r to call replace function